### PR TITLE
Add PopcornTime.app v0.5.2.2

### DIFF
--- a/Casks/popcorntime.rb
+++ b/Casks/popcorntime.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'popcorntime' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://popcorn-time.se/PopcornTime-latest.dmg'
+  name 'Popcorn Time'
+  homepage 'http://popcorn-time.se/'
+  license :gpl
+
+  app 'PopcornTime.app'
+end


### PR DESCRIPTION
Popcorn Time is a multi-platform, open source BitTorrent client which includes an integrated media player. The program is a free alternative to subscription-based video streaming services such as Netflix. Popcorn Time uses sequential downloading to play copies of films listed by the website yts.to, also known as YIFY (although other trackers can be added and used manually).
